### PR TITLE
fix npm i for dependents

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,12 @@
     "replacement patterns",
     "replacements"
   ],
-  "devDependencies": {
-    "chai": "~1.9.0",
-    "mocha": "~1.17.1",
+  "dependencies": {
     "lodash": "~2.4.1",
     "underscore.string": "~2.3.3"
+  },
+  "devDependencies": {
+    "chai": "~1.9.0",
+    "mocha": "~1.17.1"
   }
 }


### PR DESCRIPTION
Hi.
You should specify lodash as main dependencies (not dev), otherwise all dependents build will not install your libs. And get an error:

Error: Cannot find module 'lodash'
